### PR TITLE
Normalize filename before comparing

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ module.exports = function protobufJsLoader(source) {
 
             if (fs.existsSync(resolved)) {
               // Don't add a dependency on the temp file
-              if (resolved !== filename) {
+              if (resolved !== protobuf.util.path.normalize(filename)) {
                 self.addDependency(resolved);
               }
               return resolved;


### PR DESCRIPTION
Without normalizing `filename`, I'm running into the following case:

```output
resolved:  C:/Users/XXX/AppData/Local/Temp/tmp-25492-rZoK9byEw9Kc
filename:  C:\Users\XXX\AppData\Local\Temp\tmp-25492-rZoK9byEw9Kc
```

My setup is:

- Node: v16.18.1
- Windows 10
- protobufjs: 7.1.2
- protobufjs-loader: 2.0.1

